### PR TITLE
at_ndms: restore "/opt/bin/true" path 

### DIFF
--- a/at_ndms/Makefile
+++ b/at_ndms/Makefile
@@ -38,7 +38,7 @@ define Package/at/description
  (Special version for Keenetic routers)
 endef
 
-export SENDMAIL=/bin/true
+export SENDMAIL=/opt/bin/true
 EXTRA_CFLAGS:=-DNEED_YYWRAP -I$(PKG_BUILD_DIR) \
 	$(TARGET_LDFLAGS)
 


### PR DESCRIPTION
As there is no `/bin/true` in Keenetic, using `at` without `-M` gives an error message.
